### PR TITLE
benchmark for env creation: conda vs pyenv + virtualenv

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,3 +1,6 @@
+name: Benchmark
+on: pull_request
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,10 +9,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build image
         run: |
-          docker build --progress=plain -t pyenv-virtualenv .
+          docker build --progress=plain -t benchmark .
       - name: conda
         run: |
-          docker run --rm --workdir /app -v $(pwd):/app pyenv-virtualenv bash build-conda.sh
+          docker run --rm --workdir /app -v $(pwd):/app benchmark bash build-conda.sh
       - name: pyenv + virtualenv
         run: |
-          docker run --rm --workdir /app -v $(pwd):/app pyenv-virtualenv bash build-virtualenv.sh
+          docker run --rm --workdir /app -v $(pwd):/app benchmark bash build-virtualenv.sh

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,15 @@
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Benchmark
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: |
+          docker build --progress=plain -t pyenv-virtualenv .
+      - name: conda
+        run: |
+          docker run --rm --workdir /app -v $(pwd):/app pyenv-virtualenv bash build-conda.sh
+      - name: pyenv + virtualenv
+        run: |
+          docker run --rm --workdir /app -v $(pwd):/app pyenv-virtualenv bash build-virtualenv.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PATH"
 RUN eval "$(pyenv init --path)" \
     && pyenv install 3.8.10 \
-    && pyenv global 3.8.10
-RUN eval "$(pyenv init --path)" && pip install virtualenv
+    && pyenv global 3.8.10 \
+    && pip install virtualenv
 
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash Miniconda3-latest-Linux-x86_64.sh -b -p /root/miniconda3

--- a/build-conda.sh
+++ b/build-conda.sh
@@ -1,1 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+
 conda env create --name test --file conda.yaml

--- a/build-virtualenv.sh
+++ b/build-virtualenv.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -ex
 
 eval "$(pyenv init -)"
 
@@ -8,5 +9,4 @@ pyenv install --skip-existing $python_version
 virtualenv --python $(pyenv prefix $python_version)/bin/python $env_name
 source $env_name/bin/activate
 
-# Install dependencies
 pip install -r requirements.txt


### PR DESCRIPTION
Makes conda and pyenv + virtualenv create the same environment and measure how long it takes.

conda

```yaml
# conda.yaml

channels:
  - conda-forge
dependencies:
  - python=3.7.12
  - pip
  - pip:
      - scikit-learn==1.0.2
```

pyenv + virtualenv

```
# python-version
3.7.12
```

```
# requirements.txt
scikit-learn==1.0.2
```